### PR TITLE
Update serverless.yaml

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -6,7 +6,7 @@ Resources:
       Type: 'AWS::Serverless::Function'
       Properties:
         Handler: index.handler
-        Runtime: nodejs8.10
+        Runtime: nodejs12
         CodeUri: src/
         Role: !GetAtt LambdaEdgeRemoveTrailingSlashRole.Arn
         Description: 'A Lambda@Edge function to remove trailing slashes from CloudFront requests'


### PR DESCRIPTION
The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions. (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: 76f5be14-8519-42c1-b071-8c44229bca11; Proxy: null)